### PR TITLE
do not maintain version info in docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,7 +3,7 @@
 Install Kolibri
 ###############
 
-These docs are for version 0.7.x. See the `Kolibri changelog here <https://learningequality.org/r/kolibri-changes>`_. Documentation for `other versions are available here <https://readthedocs.org/projects/kolibri/>`_.
+See the `Kolibri changelog here <https://learningequality.org/r/kolibri-changes>`_. Documentation for `other versions are available here <https://readthedocs.org/projects/kolibri/>`_.
 
 To install **Kolibri**, check the system requirements first and then follow the procedure for the operating system on your device.
 


### PR DESCRIPTION
@radinamatic just noticed this: it's generally a bad idea to hard-code version information. But I would also concede that the current state of the docs is actually quite deprived of such information :) We should maybe just find a more programmatic way of doing it, since this is very easy to over-look.