### PR TITLE
Add very basic instructions to get Kolibri running on Raspberry Pi

### DIFF
--- a/docs/install/_linux.rst
+++ b/docs/install/_linux.rst
@@ -45,9 +45,35 @@ Uninstall
 * Open **Software** on Ubuntu and locate the Kolibri. Press **Remove**.
 * Or from command line: ``sudo apt-get remove kolibri``.
 
+
 Upgrade
 -------
 
 When you use the PPA installation method, upgrades to newer versions will be automatic, provided there is internet access available.
 
 To upgrade Kolibri on a Debian device without internet access, bring the updated ``.deb`` file and follow the same steps as in :ref:`lin_deb`.
+
+
+.. _raspberry_pi:
+
+Raspberry Pi (Raspbian)
+-----------------------
+
+Kolibri currently doesn't work out of the box for Raspbian Jessie due. We are
+refining our distribution to work out of the box, but you need to follow these
+two steps (tested on Kolibri 0.9):
+
+1. Running ``add-apt-repository`` as shown in the PPA instructions does not work. Instead, run::
+
+      echo "deb http://ppa.launchpad.net/learningequality/kolibri/ubuntu xenial main" > /etc/apt/sources.list.d/learningequality-ubuntu-kolibri-xenial.list
+      sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+      sudo apt update
+      sudo apt install kolibri
+
+2. Kolibri does not start after installation. This is because ``python3-cffi`` is outdated on Raspbian. Upgrade it like this::
+
+      sudo apt install libffi-dev
+      sudo pip3 install pip --upgrade
+      sudo pip3 install cffi --upgrade
+      sudo systemctl start kolibri
+

--- a/docs/install/_linux.rst
+++ b/docs/install/_linux.rst
@@ -88,8 +88,8 @@ The following issues are quite common on a Raspberry Pi:
 * You run out of storage space. If you have a USB source for additional storage, do something like this::
 
       sudo systemctl kolibri stop  # Stop kolibri
-      sudo mv /var/kolibri /your/external/media  # Move its data
-      sudo chown -R kolibri.kolibri /your/external/media/kolibri  # Ensure that the kolibri user owns the folder
-      sudo ln -s /your/external/media /var/kolibri  # Restore the original location with a symbolic link
+      sudo mv /var/kolibri/.kolibri /your/external/media/kolibri_data  # Move its data
+      sudo chown -R kolibri /your/external/media/kolibri_data  # Ensure that the kolibri user owns the folder
+      sudo ln -s /your/external/media/kolibri_data /var/kolibri/.kolibri  # Restore the original location with a symbolic link
       sudo systemctl kolibri start  # Start kolibri
 

--- a/docs/install/_linux.rst
+++ b/docs/install/_linux.rst
@@ -78,8 +78,11 @@ two steps (tested on Kolibri 0.9):
       sudo systemctl start kolibri
 
 
+.. warning: Loading channels can take a **long time** on a Raspberry Pi. When generating channel contens for Khan Academy, * Generating channel listing. This could take a few minutes…* means ~30 minutes. The device's computation power is the bottleneck. You might get logged out while waiting, but this is harmless and the process will continue. Sit tight!
+
+
 Troubleshooting
-~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^
 
 The following issues are quite common on a Raspberry Pi:
 

--- a/docs/install/_linux.rst
+++ b/docs/install/_linux.rst
@@ -77,3 +77,19 @@ two steps (tested on Kolibri 0.9):
       sudo pip3 install cffi --upgrade
       sudo systemctl start kolibri
 
+
+Troubleshooting
+~~~~~~~~~~~~~~~
+
+The following issues are quite common on a Raspberry Pi:
+
+* The time isn't set properly and you will have errors downloading software. For instance, SSL certificates for online sources will fail to validate. Ensure that you have the right timezone in ``/etc/timezone`` and that the clock is set properly by running ``sudo ntpd -gq``.
+
+* You run out of storage space. If you have a USB source for additional storage, do something like this::
+
+      sudo systemctl kolibri stop  # Stop kolibri
+      sudo mv /var/kolibri /your/external/media  # Move its data
+      sudo chown -R kolibri.kolibri /your/external/media/kolibri  # Ensure that the kolibri user owns the folder
+      sudo ln -s /your/external/media /var/kolibri  # Restore the original location with a symbolic link
+      sudo systemctl kolibri start  # Start kolibri
+


### PR DESCRIPTION
@radinamatic this is really urgent IMO because Kolibri currently does **not** work on Raspbian without these special steps.

Please feel free to make any changes to this!

@lyw07 FYI :)