### PR TITLE
Make PEX install easier for first-time Terminal users

### DIFF
--- a/docs/install/_osx.rst
+++ b/docs/install/_osx.rst
@@ -17,12 +17,21 @@ Install
 To install Kolibri on Linux distributions other than Debian, as well as on MacOS, you can use :ref:`generic installation <pip-installation>` with ``pip install`` command, or follow these steps to run Kolibri with the ``PEX`` package. 
 
 #. Download the `Kolibri PEX installer <https://learningequality.org/r/kolibri-pex-latest>`_.
-#. Open Terminal in the folder where ``PEX`` file is located and run the command:
+#. Make sure to **open the Terminal where you downloaded** the ``PEX`` file. For example, if you saved it in the *Downloads* folder, type this when you open the Terminal, and press Enter:
+
+	.. code-block:: bash
+
+	  cd Downloads
+
+#. Type the following commands next (press Enter after each one). 
+
 
 	.. code-block:: bash
 
 	  chmod +x kolibri-installer-filename.pex
 	  ./kolibri-installer-filename.pex start
+
+	.. warning:: Make sure to **substitute the** ``kolibri-installer-filename.pex`` **with the exact name of the file you downloaded**. For example, if the of the downloaded file is ``kolibri-v0.9.2.pex``, type that instead of ``kolibri-installer-filename.pex``. 
 
 #. When the command finishes, open the default browser at http://127.0.0.1:8080 and proceed with the :ref:`setup_initial` of your facility. 
 

--- a/docs/install/_osx.rst
+++ b/docs/install/_osx.rst
@@ -31,7 +31,7 @@ To install Kolibri on Linux distributions other than Debian, as well as on MacOS
 	  chmod +x kolibri-installer-filename.pex
 	  ./kolibri-installer-filename.pex start
 
-	.. warning:: Make sure to **substitute the** ``kolibri-installer-filename.pex`` **with the exact name of the file you downloaded**. For example, if the of the downloaded file is ``kolibri-v0.9.2.pex``, type that instead of ``kolibri-installer-filename.pex``. 
+	.. warning:: Make sure to **substitute the** ``kolibri-installer-filename.pex`` **with the exact name of the file you downloaded** in both commands. For example, if the name of the downloaded file is ``kolibri-v0.9.2.pex``, type that instead of ``kolibri-installer-filename.pex``. 
 
 #. When the command finishes, open the default browser at http://127.0.0.1:8080 and proceed with the :ref:`setup_initial` of your facility. 
 

--- a/docs/manage/_content.rst
+++ b/docs/manage/_content.rst
@@ -31,7 +31,7 @@ Import Content into Kolibri
 
 
 .. tip::
-  As a precaution, we recommend you avoid other interactions with Kolibri (navigate away or manage users, for example) while content import is in progress.
+  As a precaution, we recommend you avoid other interactions with Kolibri (view learner pages or manage users, for example) while content import is in progress.
 
 
 To import content into Kolibri, follow these steps.

--- a/docs/manage/_get_support.rst
+++ b/docs/manage/_get_support.rst
@@ -55,7 +55,7 @@ Open the ``.kolibri`` folder inside the :ref:`Home <home>` folder of the device 
 * ``kolibri.log``
 * ``debug.log``
 
-.. warning:: On Linux and MacOS systems you will need to activate the *Show hidden folders* option in your file browser, in order to view the ``.kolibri`` folder.
+.. warning:: On Linux and MacOS systems you will need to activate the *Show Hidden Files* option in your file browser, in order to view the ``.kolibri`` folder.
 
 Videos are not playing
 ----------------------

--- a/docs/manage/_get_support.rst
+++ b/docs/manage/_get_support.rst
@@ -50,11 +50,12 @@ Locate Kolibri log files
 
 When you report a problem with Kolibri, we may ask you to send us Kolibri **log** files to help us find out why is it not working or crashing. 
 
-Open the ``.kolibri`` folder inside the :ref:`Home <home>` of the device where Kolibri is running and locate these two files:
+Open the ``.kolibri`` folder inside the :ref:`Home <home>` folder of the device where Kolibri is running and locate these two files:
 
 * ``kolibri.log``
 * ``debug.log``
 
+.. warning:: On Linux and MacOS systems you will need to activate the *Show hidden folders* option in your file browser, in order to view the ``.kolibri`` folder.
 
 Videos are not playing
 ----------------------


### PR DESCRIPTION

- Makes the steps for users with no experience using Terminal easier to understand and execute (issue reported by @laurenlichtman).
- Fixes #24 .
- Added the warning to activate *Show Hidden Files* option in order to view log files.