### PR TITLE
Use explicit protocol, thanks @ivanistheone

### DIFF
--- a/docs/install/_rpi.rst
+++ b/docs/install/_rpi.rst
@@ -15,7 +15,7 @@ Install
 
       sudo apt install dirmngr
       sudo su -c 'echo "deb http://ppa.launchpad.net/learningequality/kolibri/ubuntu xenial main" > /etc/apt/sources.list.d/learningequality-ubuntu-kolibri-xenial.list'
-      sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+      sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
       sudo apt update
       sudo apt install kolibri
 


### PR DESCRIPTION
Pulling this change back to a reasonably old version of the docs.

Ref: https://github.com/learningequality/kolibri-server/issues/8#issuecomment-455916223