### PR TITLE
Separate Debian instructions for PPA from Ubuntu instructions

### DIFF
--- a/docs/install/_linux.rst
+++ b/docs/install/_linux.rst
@@ -6,19 +6,30 @@ Debian/Ubuntu
 Compatibility
 -------------
 
-Debian/Ubuntu 14.04 and up - anything that's *not* end-of-life
+
+Debian 8 (Jessie), Debian 9 (Stretch), Ubuntu 14.04+ and up - anything that's *not* end-of-life. Ubuntu-based distributions count a number of flavours, for instance Xubuntu and Mint.
 
 .. _ppa:
 
 Install from PPA repository
 ---------------------------
 
-Use the following commands in `Terminal <https://help.ubuntu.com/community/UsingTheTerminal>`_ to add the PPA and install Kolibri:
+**In Ubuntu-based distributions**, use the following commands in `Terminal <https://help.ubuntu.com/community/UsingTheTerminal>`_ to add the PPA and install Kolibri:
 
 .. code-block:: bash
 
-    sudo apt-get install software-properties-common python-software-properties
+    sudo apt-get install software-properties-common dirmngr
     sudo add-apt-repository ppa:learningequality/kolibri
+    sudo apt-get update
+    sudo apt-get install kolibri
+
+**In Debian-based distributions** you need to use these commands to point to our Launchpad PPA:
+
+.. code-block:: bash
+
+    sudo apt-get install software-properties-common dirmngr
+    sudo su -c 'echo "deb http://ppa.launchpad.net/learningequality/kolibri/ubuntu cosmic main" > /etc/apt/sources.list.d/learningequality-ubuntu-kolibri-cosmic.list'
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
     sudo apt-get update
     sudo apt-get install kolibri
 


### PR DESCRIPTION
Fixes #60 

I had a look at the current Raspberry Pi documentation, and it's way too specific for RPi to mix in Debian in general. There is also #52 to take into account.