### PR TITLE
Minor Typo: Raspbian

### DIFF
--- a/docs/install/_rpi.rst
+++ b/docs/install/_rpi.rst
@@ -3,7 +3,7 @@
 Raspberry Pi
 ============
 
-There are several varieties of operating systems for Raspberry Pi. This guide is intended for and tested on `Raspian <https://www.raspberrypi.org/>`__, the most popular choice of OS, based on Debian. To obtain and install Raspbian, refer to the official documentation.
+There are several varieties of operating systems for Raspberry Pi. This guide is intended for and tested on `Raspbian <https://http://raspbian.org//>`__, the most popular choice of OS, based on Debian. To obtain and install Raspbian, refer to the official documentation.
 
 Kolibri is intended for **Raspberry Pi Model 3** and upwards.
 


### PR DESCRIPTION
The correct spelling is "Raspbian" and the project address is 
http://raspbian.org/. 

Alternatively you also use the following URI as well https://www.raspberrypi.org/downloads/