### PR TITLE
Add lint target to .travis job - should have always been there

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 
 # command to run tests
 script:
+  - make lint
   - make docs
   - make clean
   - make docs-translated lang=es


### PR DESCRIPTION
Fixes #86 

There was a clear mistake in the Travis configuration, thanks @indirectlylit for inspiring me to consolidate this.