### PR TITLE
Delete 'IP' 

### DIFF
--- a/docs/access.rst
+++ b/docs/access.rst
@@ -91,7 +91,7 @@ Set up Access on Other Devices
 
 To access content from other devices in the same network, you need to know the :ref:`IP address <ips>` of the computer where Kolibri is running. The default port is **8080**, and you must add it after the IP address.
 
-For example, if Kolibri is installed and started on a computer with the IP address **192.168.8.134:8080**, you can access it from an Android tablet connected to the same network by opening the browser on the tablet and typing the address ``http://192.168.8.134:8080``.
+For example, if Kolibri is installed and started on a computer with the address **192.168.8.134:8080**, you can access it from an Android tablet connected to the same network by opening the browser on the tablet and typing the address ``http://192.168.8.134:8080``.
 
 
 .. tip::


### PR DESCRIPTION
TIL that _IP address_ with specified port is not, in fact, **IP** 🙂  