### PR TITLE
Warning to include "http://" when accessing the server

### DIFF
--- a/docs/access.rst
+++ b/docs/access.rst
@@ -119,7 +119,7 @@ For example, if Kolibri is installed and started on a computer with the address 
 
 
 .. warning::
-  * When limited to using older browsers it may be necessary to **explicitly include** the ``http://`` in front of the IP in the address bar, for example ``http://192.168.8.134:8080``. Many modern browsers may also take the IP address or the local network hostname as a search term and redirect you to Google. In other cases, browsers may try to use the secure **HTTPS** protocol by default and add an **S**  automatically (``httpS://``), which may also cause issues while running Kolibri.
+  * When entering the URL in the browser, it may be required to explicitly include `http://`, for example `http://1.2.3.4:8080` or `http://1.2.3.4:80`. Many browsers will incorrectly interpret an IP address or local network hostname as a search term. In other cases, browsers may incorrectly add `https://` instead of `http://`.
   
   * In case you decide to make Kolibri available on the port 80, instead of the default 8080, you **must always include** ``http://`` in front of the server's IP.
     

--- a/docs/access.rst
+++ b/docs/access.rst
@@ -119,10 +119,10 @@ For example, if Kolibri is installed and started on a computer with the address 
 
 
 .. warning::
-  * On older operating systems and browsers it might be necessary to **explicitly include** the ``http://`` in the address bar when accessing the server's IP. Recent browser versions should redirect it properly even if you write just the IP, but be sure to include ``http://`` if you have Kolibri running on older devices and encountering issues accessing the server's IP.
+  * When limited to using older browsers it may be necessary to **explicitly include** the ``http://`` in front of the IP in the address bar, for example ``http://192.168.8.134:8080``. Many modern browsers may also take the IP address or the local network hostname as a search term and redirect you to Google. In other cases, browsers may try to use the secure **HTTPS** protocol by default and add an **S**  automatically (``httpS://``), which may also cause issues while running Kolibri.
   
   * In case you decide to make Kolibri available on the port 80, instead of the default 8080, you **must always include** ``http://`` in front of the server's IP.
-
+    
 
 .. note::
   * In case of network problems, see :ref:`troubleshooting tips <network>`.

--- a/docs/access.rst
+++ b/docs/access.rst
@@ -118,6 +118,12 @@ For example, if Kolibri is installed and started on a computer with the address 
   * You can also use the ``ipconfig`` command on Windows or ``ifconfig`` command on Linux/OSX to find the externally visible IP address of the device running the Kolibri.
 
 
+.. warning::
+  * On older operating systems and browsers it might be necessary to **explicitly include** the ``http://`` in the address bar when accessing the server's IP. Recent browser versions should redirect it properly even if you write just the IP, but be sure to include ``http://`` if you have Kolibri running on older devices and encountering issues accessing the server's IP.
+  
+  * In case you decide to make Kolibri available on the port 80, instead of the default 8080, you **must always include** ``http://`` in front of the server's IP.
+
+
 .. note::
   * In case of network problems, see :ref:`troubleshooting tips <network>`.
   * Examples and comparison of `Hardware Configurations for Kolibri <https://learningequality.org/r/hardware>`__ (PDF document).


### PR DESCRIPTION
Fixes #129.

![2019-09-13_3-11-51](https://user-images.githubusercontent.com/1457929/64831656-f6b0a480-d5d6-11e9-9e6e-bf719ea5ec83.png)

