### PR TITLE
Add better guidance for installing Kolibri from pip

### DIFF
--- a/docs/install/python.rst
+++ b/docs/install/python.rst
@@ -12,7 +12,13 @@ You can install Kolibri as a standard package from PyPi (works on Mac, Windows, 
 
 .. code-block:: bash
 
-  pip install kolibri
+  # Install for your current user
+  pip install --user kolibri
+
+  # Install system-wide (all users)
+  sudo pip install kolibri
+
+After Kolibri has been installed from PyPi, a new ``kolibri`` command should be available in your Terminal application.
 
 
 .. _pex:


### PR DESCRIPTION
@indirectlylit commented on this somewhere and I wrote a PR instead of commenting back that I agree :)

I also added a not that this makes the `kolibri` command available from command line, since this is slightly different from other installers that add system services and short cuts.

I think that users of virtualenvs will know very well not to use `--user` or `sudo`, so an instruction for them should be superfluous.