### PR TITLE
update mac installation instructions

### DIFF
--- a/docs/install/macos.rst
+++ b/docs/install/macos.rst
@@ -11,6 +11,8 @@ Kolibri macOS app has been tested on High Sierra (10.13), Mojave (10.14), and Ca
 Install
 -------
 
+.. note:: The Kolibri Mac app is not signed, which means that you must tell MacOS to allow it to run. Read `more information about opening unsigned apps <https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac>`_ from Apple.
+
 #. Download the `.dmg installer <https://learningequality.org/download/>`_ for Kolibri **version 0.13**.
 #. Double-click the downloaded ``.dmg`` file.
 #. Drag the Kolibri logo inside the **Applications** folder, and wait for the installation to finish.
@@ -18,15 +20,7 @@ Install
    .. figure:: /img/copy-app.png
      :alt: 
 
-4. a) **The first time you start the Kolibri application, do NOT use Launchpad**. Instead use the **Finder** on your Mac to locate Kolibri in the **Applications** folder. This is because the application is unsigned and needs your permission to run.
-
-   b) Control-click the app icon, then choose **Open** from the shortcut menu.
-
-      After completing these steps, your security settings are updated for this version of Kolibri, and you can launch Kolibri like any other application. You may need to repeat this process when you upgrade Kolibri.
-
-
-      .. note:: Read this for `more details about opening unsigned apps <https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac>`_.
-
+4. When you initially run or upgrade Kolibri, locate the app in the **Finder**. Control-click the app icon, then choose **Open** to allow the unsigned app to run.
 #. Proceed with the :ref:`setup_initial` of Kolibri. 
 
 

--- a/docs/install/macos.rst
+++ b/docs/install/macos.rst
@@ -13,7 +13,7 @@ Install
 
 .. note:: The Kolibri Mac app is not signed, which means that you must tell MacOS to allow it to run. Read `more information about opening unsigned apps <https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac>`_ from Apple.
 
-#. Download the `.dmg installer <https://learningequality.org/download/>`_ for Kolibri **version 0.13**.
+#. Download the `.dmg installer <https://learningequality.org/r/kolibri-mac-latest>`__ for Kolibri **version 0.13**.
 #. Double-click the downloaded ``.dmg`` file.
 #. Drag the Kolibri logo inside the **Applications** folder, and wait for the installation to finish.
    


### PR DESCRIPTION
The mac installation instructions are still a bit confusing and over-complicated. The nested list is also strangely formatted.

Trying to simplify things a bit here:

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/74805271-7550f280-5297-11ea-9c51-666fd3dd6bef.png) |![image](https://user-images.githubusercontent.com/2367265/74805385-c5c85000-5297-11ea-9a8d-8d74f621e7d8.png)|


This also provides a direct link to the DMG due to https://github.com/learningequality/learningequality.org/pull/486