### PR TITLE
Add a "Disallow" directive to robots.txt

### DIFF
--- a/docs/extras/robots.txt
+++ b/docs/extras/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
+Disallow: /
 Allow: /*/latest/


### PR DESCRIPTION
> At a group-member level, in particular for allow and disallow directives, the most specific rule based on the length of the [path] entry trumps the less specific (shorter) rule. In case of conflicting rules, including those with wildcards, the least restrictive rule is used. 

I assume that there is some kind of `Allow: /` implicitly at stake, and we have to disallow (blacklist) everything if we want a whitelist (Allow).

I cannot find any direct reference to how a clean whitelist should look, I found this:

> The Allow directive
>
> While not in the original “specification”, there was talk very early on of an allow directive. Most search engines seem to understand it, and it allows for simple, and very readable directives like this: (...)

https://yoast.com/ultimate-guide-robots-txt/#allow-directive

Ref: https://github.com/learningequality/kolibri-docs/issues/48