### PR TITLE
Prefer `apt install` since 16.04

### DIFF
--- a/docs/install/ubuntu-debian.rst
+++ b/docs/install/ubuntu-debian.rst
@@ -49,14 +49,14 @@ When you use the PPA installation method, upgrades to newer versions will be aut
 Install from a .deb file
 ------------------------
 
-The advantages of downloading a ``.deb`` file is the portability: you can copy the file from device to device and install Kolibri without internet access.
+The advantages of downloading a ``.deb`` file is the portability: You can copy the file from device to device and install Kolibri without internet access.
 
 #. Download the latest `.deb installer <https://learningequality.org/download/>`_ for Kolibri **version 0.13**, or have it copied to your local drive.
-#. Run this command from the location where you downloaded the ``DEB`` file:
+#. Run this command from the location where you downloaded the ``.deb`` file:
 
    .. code-block:: bash
 
-       sudo dpkg -i kolibri-installer-filename.deb
+       sudo apt install --fix-missing ./KOLIBRI_FILENAME.deb
 
 #. Wait for the installation to finish and run this command to start Kolibri:
 
@@ -67,6 +67,9 @@ The advantages of downloading a ``.deb`` file is the portability: you can copy t
    .. note:: If you choose to install Kolibri as a system service, you will not need to start it manually.
 
 #. When the command finishes, open the default browser at http://127.0.0.1:8080 and proceed with the :ref:`setup_initial` of your facility. 
+
+.. tip::
+  The package ``python3-cryptography`` speeds up Kolibri for future peer-to-peer synchronization. It is installed automatically if there is an internet connection. You can download a version of this package in a .deb file **for your current system** with ``apt download python3-cryptography`` and install it using the same technique as shown above.
 
 
 Uninstall
@@ -110,6 +113,8 @@ To change the system service owner, you need to change the configuration of the 
 
 .. note:: Replace the ``$USER`` in commands above with the name of the user you wish to be the new Kolibri system service owner.
 
+
+.. _kolibri-server-install:
 
 Higher Performance with the ``kolibri-server`` package
 ------------------------------------------------------


### PR DESCRIPTION
Learned that `apt install` also works on .deb files since 16.04 and will install dependencies as well. Since we recommend `python3-cryptography`, this change could potentially ensure that people don't miss out on it.

~I need to make a test to see what happens when someone is offline and does not have `python3-cryptography`~ Tested: It will fail unless `--fix-missing` is added.

I added a tip box in the docs. I think this is the only place where we currently have information about why this package is a dependency. Installing Kolibri as a portable .deb can be a nice experience, just this little tip became more important since 20.04 runs Python 3.8 and won't benefit from bundled C extensions (cext).

![image](https://user-images.githubusercontent.com/374612/81082731-f3ff1880-8ef3-11ea-9a10-86cc1862fe06.png)
