### PR TITLE
 typofix in bulkimportusers CLI examples

### DIFF
--- a/docs/manage/command_line.rst
+++ b/docs/manage/command_line.rst
@@ -153,21 +153,21 @@ Execute the *dry-run* of the command to review the report containing the number 
 
 .. code-block:: bash
 
-  kolibri manage bulkimportusers --dryrun my-school-users-2020.csv
+  kolibri manage bulkimportusers --dryrun my-school-users-2021.csv
 
 
 Run the command and review that the changes are visible in the **Facility** dashboard.
 
 .. code-block:: bash
 
-  kolibri manage bulkimportusers my-school-users-2020.csv
+  kolibri manage bulkimportusers my-school-users-2021.csv
 
 
 If the CSV file does not contain all the non admin users or classes currently in the facility, using the ``--delete`` flag will remove them during the import process.
 
 .. code-block:: bash
 
-  kolibri manage bulkimportusers --delete my-school-users-2020.csv
+  kolibri manage bulkimportusers --delete my-school-users-2021.csv
 
 
 Export to CSV
@@ -177,14 +177,14 @@ Run the following command to create a ``users_<date>_<time>.csv`` file.
 
 .. code-block:: bash
 
-  kolibri manage bulkexportusers --overwrite --output-file=my-school-users-2020.csv
+  kolibri manage bulkexportusers --overwrite --output-file=my-school-users-2021.csv
 
 
 To export a CSV file with localized headers, use the ``--locale`` flag.
 
 .. code-block:: bash
 
-  kolibri manage bulkexportusers --overwrite --output-file=lista-estudiantes-2020.csv --locale=es_ES
+  kolibri manage bulkexportusers --overwrite --output-file=lista-estudiantes-2021.csv --locale=es_ES
 
 
 

--- a/docs/manage/command_line.rst
+++ b/docs/manage/command_line.rst
@@ -153,21 +153,21 @@ Execute the *dry-run* of the command to review the report containing the number 
 
 .. code-block:: bash
 
-  kolibri manage bulkimportusers --dryrun --output-file=my-school-users-2020.csv
+  kolibri manage bulkimportusers --dryrun my-school-users-2020.csv
 
 
 Run the command and review that the changes are visible in the **Facility** dashboard.
 
 .. code-block:: bash
 
-  kolibri manage bulkimportusers --output-file=my-school-users-2020.csv
+  kolibri manage bulkimportusers my-school-users-2020.csv
 
 
 If the CSV file does not contain all the non admin users or classes currently in the facility, using the ``--delete`` flag will remove them during the import process.
 
 .. code-block:: bash
 
-  kolibri manage bulkimportusers --delete --output-file=my-school-users-2020.csv
+  kolibri manage bulkimportusers --delete my-school-users-2020.csv
 
 
 Export to CSV


### PR DESCRIPTION
small fix spotted via the twitters https://twitter.com/LearnEQ/status/1358802695537180676

relevant mgmt command source is https://github.com/learningequality/kolibri/blob/release-v0.14.x/kolibri/core/auth/management/commands/bulkimportusers.py#L354-L396 
which shows `filepath` is regular arg, not `--output-file` kwarg