### PR TITLE
Fix broken links

### DIFF
--- a/docs/access/macos.rst
+++ b/docs/access/macos.rst
@@ -6,7 +6,7 @@ MacOS
 Use the Kolibri icon in the Launchpad to open the app on macOS.
 
 .. warning::
-   If you are using keyboard navigation on macOS, be sure to `enable 'All Controls' in the 'System Preferences' <https://a11yproject.com/posts/2017-12-29-macos-browser-keyboard-navigation/>`_.
+   If you are using keyboard navigation on macOS, be sure to `enable 'All Controls' in the 'System Preferences' <https://www.a11yproject.com/posts/2017-12-29-macos-browser-keyboard-navigation/>`_.
 
 .. note::
   Remember to :ref:`configure other computers <access_LAN>` in the network to access **Kolibri**.

--- a/docs/install/raspberry_pi.rst
+++ b/docs/install/raspberry_pi.rst
@@ -28,7 +28,7 @@ After following the above steps the Raspberry Pi will provide a WiFi network nam
 By default the server does not have Internet access. To import resources to Kolibri, either connect a USB drive with exported channels, or connect the Pi to an internet-connected router using the ethernet cable.
 
 
-.. note:: The installed system contains a full Raspbian image, with all the software included in the ``lite`` version from https://www.raspberrypi.org/downloads/raspbian/. After login use ``sudo raspi-config`` to customize the environment, including localization, timezone, etc. if desired.
+.. note:: The installed system contains a full RPi image, with all the software included in the ``Lite`` version from https://www.raspberrypi.org/software/operating-systems/#raspberry-pi-os-32-bit. After login use ``sudo raspi-config`` to customize the environment, including localization, timezone, etc. if desired.
 
 
 .. note:: When an ethernet cable with Internet access is connected to the Raspberry, it will have internet connectivity but won't provide this connectivity to the devices that are connected to its ``kolibri`` ssid. These devices will only be able to use the browser with the Kolibri application at the URL ``http://10.10.10.10``.

--- a/docs/manage/command_line.rst
+++ b/docs/manage/command_line.rst
@@ -54,7 +54,7 @@ For example (``Channel ID`` without angle brackets ``<...>``):
   kolibri manage importchannel network a9b25ac9814742c883ce1b0579448337
   kolibri manage importcontent network a9b25ac9814742c883ce1b0579448337
 
-.. warning:: When you import channels from the command line, you still must use the **32 digit channel ID**, as the :ref:`command will not work with the token <id_token>`. Make sure to receive the correct channel ID from the person who curated the unlisted channel you need to import, or refer to `Kolibri Studio user guide <https://kolibri-studio.readthedocs.io/en/latest/share_channels.html#make-content-channels-available-for-import-into-kolibri>`_ how to find it in Studio user interface, if you have channel editor access.
+.. warning:: When you import channels from the command line, you still must use the **32 digit channel ID**, as the :ref:`command will not work with the token <id_token>`. Make sure to receive the correct channel ID from the person who curated the unlisted channel you need to import, or refer to `Kolibri Studio user guide <https://kolibri-studio.readthedocs.io/en/latest/share_channels.html#make-channels-available-for-import-into-kolibri>`_ how to find it in Studio user interface, if you have channel editor access.
 
 ..
   Commented out because the API is weird and should be fixed


### PR DESCRIPTION
Fixed a broken link from https://github.com/learningequality/kolibri/issues/7807, plus 2 more found by docs ``make lint`` command.