### PR TITLE
learn-docs: change login to sign in

### DIFF
--- a/docs/learn.rst
+++ b/docs/learn.rst
@@ -109,7 +109,7 @@ Learn with Kolibri
 Classes
 ^^^^^^^
 
-Each time you login into **Kolibri**, the first thing you will see is the |learn| **Learn** page with the list of all the classes you are enrolled to. 
+Each time you sign in to **Kolibri**, the first thing you will see is the |learn| **Learn** page with the list of all the classes you are enrolled to. 
 
 	.. figure:: img/learn-classes.png
 	  :alt: 


### PR DESCRIPTION
Removed the term 'login' and replaced it with 'sign in' to maintain consistency. 'Sign in' is the term used across the rest of the Kolibri docs.