### PR TITLE
Add link to Running Kolibri on a different port when the default port is in use

### DIFF
--- a/docs/access/linux.rst
+++ b/docs/access/linux.rst
@@ -18,7 +18,7 @@ Starting Kolibri on Linux will differ depending on the method you used to instal
       kolibri start
 
     .. note::
-      By default **Kolibri** starts on 8080 port. If the default port is in use, then refer to `this <https://kolibri.readthedocs.io/en/latest/manage/options_ini.html#run-kolibri-from-a-different-port>`_ doc for running it from a different port.
+      By default **Kolibri** starts on 8080 port. If the default port is in use, then refer to :ref:`this <different_port>` doc for running it from a different port.
 
   2. Open the default browser at ``http://127.0.0.1:8080``, and it will display the **Kolibri** start page.
 

--- a/docs/access/linux.rst
+++ b/docs/access/linux.rst
@@ -18,7 +18,7 @@ Starting Kolibri on Linux will differ depending on the method you used to instal
       kolibri start
 
     .. note::
-      By default **Kolibri** starts on 8080 port. If the default port is in use, then refer to :ref:`this <different_port>` doc for running it from a different port.
+      By default **Kolibri** starts on 8080 port. If the default port is in use, refer to :ref:`Running Kolibri from a different port <different_port>`.
 
   2. Open the default browser at ``http://127.0.0.1:8080``, and it will display the **Kolibri** start page.
 

--- a/docs/access/linux.rst
+++ b/docs/access/linux.rst
@@ -16,7 +16,9 @@ Starting Kolibri on Linux will differ depending on the method you used to instal
     .. code-block:: bash
 
       kolibri start
-      
+
+    .. note::
+      By default **Kolibri** starts on 8080 port. If the default port is in use, then refer to `this <https://kolibri.readthedocs.io/en/latest/manage/options_ini.html#run-kolibri-from-a-different-port>`_ doc for running it from a different port.
 
   2. Open the default browser at ``http://127.0.0.1:8080``, and it will display the **Kolibri** start page.
 

--- a/docs/manage/options_ini.rst
+++ b/docs/manage/options_ini.rst
@@ -12,6 +12,8 @@ Installing Kolibri generates a default ``options.ini`` file with all the section
 Manage Server Ports
 *******************
 
+.. _different_port:
+
 Run Kolibri from a different port
 ---------------------------------
 


### PR DESCRIPTION
For someone initially setting up Kolibri, getting the default port 8080 already in use is a common issue, it will be better if a note is provided to the end users in advance with the reference to the doc for running Kolibri on a different port.