### PR TITLE
Update ReadTheDocs builds configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+version: 2
+formats: all
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+sphinx:
+  configuration: docs/conf.py
+python:
+  install:
+    - requirements: requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,7 @@ import os
 import sys
 from datetime import datetime
 
+import sphinx_rtd_theme
 from sphinx.builders.html import StandaloneHTMLBuilder
 
 # IMPORTANT! KEEP THIS UPDATED TO REFLECT WHICH VERSION THESE DOCS ARE WRITTEN
@@ -92,11 +93,8 @@ if on_rtd:
         "sphinx-apidoc --doc-project='Python Reference' -f -o . ../kolibri ../kolibri/test ../kolibri/deployment/ ../kolibri/dist/"
     )
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [".", sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "sphinx_rtd_theme"
+html_theme_path = [".", sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
## Summary

- Starting on September 25, ReadTheDocs builds without configuration file won't work anymore. This adds the configuration file.
- Enables `sphinx-rtd-theme` for the production build
  - Previously, it was enabled only for local builds, probably because it was applied by default by ReadTheDocs. However, ReadTheDocs is generally moving towards requiring explicit configuration and having the theme disabled for production seems to be the cause of some recent troubles with theme in one of our products.

## References

https://blog.readthedocs.com/migrate-configuration-v2/

## Reviewer guidance

- Preview the configuration file
- Preview the production docs build: https://kolibri--246.org.readthedocs.build/en/246/
- Preview the local docs build