### PR TITLE
Add  missing definition for client devices

### DIFF
--- a/docs/access/access_lan.rst
+++ b/docs/access/access_lan.rst
@@ -8,10 +8,10 @@ Here are definitions of concepts necessary to understand how Kolibri works in yo
 .. glossary::
 
     Server
-      Any device that can make digital data (videos, files, etc.) available for browsing, either to other clients and peers on the local network, or publicly on the Internet. When Kolibri is installed and run on a device, it effectively turns that device into a ‘Kolibri server’, which means that device is capable of transmitting (‘serving’) educational resources. 
+      Any device that can make digital data (videos, files, etc.) available for browsing, either to other clients and peers on the local network, or publicly on the Internet. When Kolibri is installed and run on a device, it effectively turns that device into a ‘Kolibri server’, which means that device is capable of transmitting (‘serving’) educational resources in the local network. 
 
     Client
-      TO-DO
+      Any device in a local network that uses a browser to access the educational resources available on the Kolibri server device running in that same network.
 
 After you have installed and started Kolibri on the computer that will act as a server, you need to configure other devices in the same `Local Area Network <https://en.wikipedia.org/wiki/Local_area_network>`_ (LAN), such as other computers, tablets or phones, so they can access as clients the learning resources on the server.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,7 @@ import os
 import sys
 from datetime import datetime
 
+import sphinx_rtd_theme
 from sphinx.builders.html import StandaloneHTMLBuilder
 
 # IMPORTANT! KEEP THIS UPDATED TO REFLECT WHICH VERSION THESE DOCS ARE WRITTEN
@@ -92,11 +93,9 @@ if on_rtd:
         "sphinx-apidoc --doc-project='Python Reference' -f -o . ../kolibri ../kolibri/test ../kolibri/deployment/ ../kolibri/dist/"
     )
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
+html_theme = "sphinx_rtd_theme"
 
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [".", sphinx_rtd_theme.get_html_theme_path()]
+html_theme_path = [".", sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,0 +1,11 @@
+version: 2
+formats: all
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+sphinx:
+  configuration: docs/conf.py
+python:
+  install:
+    - requirements: requirements.txt


### PR DESCRIPTION
Fixes the [issue reported on Slack](https://learningequality.slack.com/archives/C4HNGQJGH/p1701982808654129).